### PR TITLE
Combine both active and expired silences to deal with change in 0.13.0 --expire option

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -20,18 +20,26 @@ silence_id=$(jq -r '.version.ref // ""' < ${payload})
 
 echo "${silence_id}" > "${destination_dir}/silence"
 
-amtool --alertmanager.url ${url} \
-       --output json \
-       silence query --expired | \
-       jq -e ".[] | select(.id == \"${silence_id}\") | {
-         version: { ref: .id },
-         metadata: [
-           { name: \"created_by\", value: .createdBy },
-           { name: \"comment\", value: .comment },
-           { name: \"starts_at\", value: .startsAt },
-           { name: \"ends_at\", value: .endsAt },
-           { name: \"updated_at\", value: .updatedAt }
-         ]
-        }" >&3
+am_active=$(amtool --alertmanager.url ${url} \
+                   --output json \
+                   silence query)
+
+am_expired=$(amtool --alertmanager.url ${url} \
+                   --output json \
+                   silence query --expired)
+
+am_all=$(echo "${am_active}" "${am_expired}" | jq -s add)
+
+echo "${am_all}" | \
+     jq -e ".[] | select(.id == \"${silence_id}\") | {
+       version: { ref: .id },
+       metadata: [
+         { name: \"created_by\", value: .createdBy },
+         { name: \"comment\", value: .comment },
+         { name: \"starts_at\", value: .startsAt },
+         { name: \"ends_at\", value: .endsAt },
+         { name: \"updated_at\", value: .updatedAt }
+       ]
+      }" >&3
 
 exit 0


### PR DESCRIPTION
Combine active and expired silences. Handles change introduced in 0.13.0: [amtool] silence query: --expired flag only shows expired silences ([#1190](https://github.com/prometheus/alertmanager/pull/1190)), solves issue mentioned in https://github.com/frodenas/alertmanager-resource/issues/1