### PR TITLE
Upgrade to alert-manager v0.15.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV jq_version=1.5
 ADD https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq
 
-ENV alertmanager_version=0.14.0
+ENV alertmanager_version=0.15.3
 ADD https://github.com/prometheus/alertmanager/releases/download/v${alertmanager_version}/alertmanager-${alertmanager_version}.linux-amd64.tar.gz /tmp/alertmanager-${alertmanager_version}.linux-amd64.tar.gz
 RUN tar xzvf /tmp/alertmanager-${alertmanager_version}.linux-amd64.tar.gz -C /tmp alertmanager-${alertmanager_version}.linux-amd64/amtool && \
     mv /tmp/alertmanager-${alertmanager_version}.linux-amd64/amtool /usr/local/bin/amtool && \

--- a/assets/out
+++ b/assets/out
@@ -26,7 +26,7 @@ if [[ "${operation}" == "silence" ]]; then
                       silence add \
                       --author "${creator}" \
                       --comment "${comments}" \
-                      --expires "${expires}" \
+                      --duration="${expires}" \
                       ${matchers})
 
 	amtool --alertmanager.url ${url} \


### PR DESCRIPTION
Hi, we are using alert-manager v0.15.3 and your resource needed some little adaptations to be able to work with this version.

This will probably break compatibility with v0.14, so you may want to tag your resource with the alertmanager's version it works with in dockerhub before merging this PR.